### PR TITLE
Add entity_picture attribute to user entity as avatar

### DIFF
--- a/custom_components/duolingo/entity.py
+++ b/custom_components/duolingo/entity.py
@@ -133,8 +133,6 @@ class DuolingoSensor(CoordinatorEntity[DuolingoDataCoordinator], SensorEntity):
                                 if "value" in list(attr.keys()):
                                     if attr.get('name') == 'avatar':
                                         # Set the entity_picture attribute for use with entity badge and similar Lovelace cards
-                                        # FIXME: Should this completely replace the avatar as an if/else statement?
-                                        #        Would need to co-ordinate such a change with https://github.com/Makhuta/lovelace-duolingo-card
                                         output['entity_picture'] = attr.get('value')(data)
                                     output[attr.get("name")] = attr.get("value")(data)
                                 else:

--- a/custom_components/duolingo/entity.py
+++ b/custom_components/duolingo/entity.py
@@ -131,6 +131,11 @@ class DuolingoSensor(CoordinatorEntity[DuolingoDataCoordinator], SensorEntity):
                                 if not attr.get("name"):
                                     continue
                                 if "value" in list(attr.keys()):
+                                    if attr.get('name') == 'avatar':
+                                        # Set the entity_picture attribute for use with entity badge and similar Lovelace cards
+                                        # FIXME: Should this completely replace the avatar as an if/else statement?
+                                        #        Would need to co-ordinate such a change with https://github.com/Makhuta/lovelace-duolingo-card
+                                        output['entity_picture'] = attr.get('value')(data)
                                     output[attr.get("name")] = attr.get("value")(data)
                                 else:
                                     output[attr.get("name")] = data


### PR DESCRIPTION
Almost certainly requires more thought as this was written as a fairly quick-and-dirty patch, but figured I'd push it as-is and think about it later.

I wanted to use a lovelace entity badge, entities card, or glance card, for multiple users, all of which use the entity_picture attribute.
HA's builtin 'person' sensors use entity_picture as the user's avatar, so figured that was the more correct answer here.

I've kept the 'avatar' attribute to avoid breaking existing uses of it, but if this is worth merging in then it's probably worth replacing 'avatar' for consistency.


I'm using this with a glance card like so (card_mod used so to display 'streak_extended_today' from separate entity)
```
type: glance
entities:
  - entity: sensor.mijofa_duolingo_user
    name: mijofa
    card_mod:
      style: |
        div.name::after {
          content: "Lesson needed!";
          display: {{'none' if state_attr('sensor.mijofa_duolingo_streak', 'streak_extended_today') else 'block' }};
          color: var(--warning-color);
        }
```
Or this fairly similar entities card:
```
type: entities
entities:
  - entity: sensor.mijofa_duolingo_user
    name: Duolingo
    card_mod:
      style:
        hui-generic-entity-row$: |
          .info.text-content::after {
            content: "{{'Streak extended today' if state_attr('sensor.mijofa_duolingo_streak', 'streak_extended_today') else 'Lesson needed'}}";
            display: block;
            color: var({{'--secondary-text-color' if state_attr('sensor.mijofa_duolingo_streak', 'streak_extended_today') else '--warning-color'}});
          }
```